### PR TITLE
let kt to remove cfn only

### DIFF
--- a/kt
+++ b/kt
@@ -169,13 +169,6 @@ sub_deploy() {
 
 sub_delete() {
   sub_compile
-  for f in $(find _build/$environment/$componentBuildPath/templates/ -type f -name "*.yaml" \
-    | grep -v "/$cfnSubfolder/" \
-    | sort -r); do
-    if [ $(is_empty_file $f) != "True" ]; then
-      kubectl delete -f $f
-    fi
-  done
   for f in $(find _build/$environment/$componentBuildPath/templates/ -type f -path "*/$cfnSubfolder/*" -name "*.yaml" | sort); do
     stackup $environment-$(basename $f .yaml) down
   done


### PR DESCRIPTION
## Why: 
when we run `kt delete`, really what we care is the AWS resources to be removed. Because those Kubernetes objects does not need to be removed separately: just blow away the entire cluster. 

Allowing this mod will:
- simplify the cluster removal process.
- make cluster removal fool-proof: operators don't have to remove k8s components + AWS resource prior to remove the cluster. Otherwise, a foolish scenario would be operator removes cluster first, then trying to run `kt` in order to remove k8s components + AWS resources, only to find `kubectl delete` bit stops working as k8s cluster is no longer running. 

## What: 
remove kube related steps. 
